### PR TITLE
Add RLS policies and auth.uid enforcement

### DIFF
--- a/db_init/functions/sp_abrir_venda_mesa.sql
+++ b/db_init/functions/sp_abrir_venda_mesa.sql
@@ -1,9 +1,8 @@
 CREATE OR REPLACE FUNCTION sp_abrir_venda_mesa(
     p_id_mesa INT,
-    p_data TIMESTAMP,
-    p_user_id UUID
+    p_data TIMESTAMP
 ) RETURNS TABLE(id_venda INT) AS $$
 INSERT INTO vendas(id_mesa, data_venda, status_aberta, cancelada, user_id)
-VALUES (p_id_mesa, p_data, TRUE, FALSE, p_user_id)
+VALUES (p_id_mesa, p_data, TRUE, FALSE, auth.uid())
 RETURNING id_venda;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_adicionar_ingrediente_producao.sql
+++ b/db_init/functions/sp_adicionar_ingrediente_producao.sql
@@ -1,12 +1,11 @@
 CREATE OR REPLACE FUNCTION sp_adicionar_ingrediente_producao(
     p_id_producao INT,
     p_id_produto INT,
-    p_quantidade NUMERIC,
-    p_user_id UUID
+    p_quantidade NUMERIC
 ) RETURNS TABLE(id INT) AS $$
 INSERT INTO producao_ingredientes(
     id_producao, id_produto, quantidade_utilizada, user_id
 ) VALUES (
-    p_id_producao, p_id_produto, p_quantidade, p_user_id
+    p_id_producao, p_id_produto, p_quantidade, auth.uid()
 ) RETURNING id;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_adicionar_ingrediente_receita.sql
+++ b/db_init/functions/sp_adicionar_ingrediente_receita.sql
@@ -1,12 +1,11 @@
 CREATE OR REPLACE FUNCTION sp_adicionar_ingrediente_receita(
     p_id_receita INT,
     p_id_produto INT,
-    p_quantidade NUMERIC,
-    p_user_id UUID
+    p_quantidade NUMERIC
 ) RETURNS TABLE(id INT) AS $$
 INSERT INTO receita_ingredientes(
     id_receita, id_produto, quantidade_utilizada, user_id
 ) VALUES (
-    p_id_receita, p_id_produto, p_quantidade, p_user_id
+    p_id_receita, p_id_produto, p_quantidade, auth.uid()
 ) RETURNING id;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_adicionar_item_pedido.sql
+++ b/db_init/functions/sp_adicionar_item_pedido.sql
@@ -4,12 +4,11 @@ CREATE OR REPLACE FUNCTION sp_adicionar_item_pedido(
     p_id_item INT,
     p_quantidade NUMERIC,
     p_preco NUMERIC,
-    p_observacao TEXT,
-    p_user_id UUID
+    p_observacao TEXT
 ) RETURNS TABLE(id_pedido_item INT) AS $$
 INSERT INTO pedido_itens(
     id_pedido, tipo_item, id_item, quantidade, preco_unitario, observacao, user_id
 ) VALUES (
-    p_id_pedido, p_tipo_item, p_id_item, p_quantidade, p_preco, p_observacao, p_user_id
+    p_id_pedido, p_tipo_item, p_id_item, p_quantidade, p_preco, p_observacao, auth.uid()
 ) RETURNING id_pedido_item;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_ajustar_estoque.sql
+++ b/db_init/functions/sp_ajustar_estoque.sql
@@ -3,12 +3,11 @@ CREATE OR REPLACE FUNCTION sp_ajustar_estoque(
     p_quantidade_anterior NUMERIC,
     p_quantidade_nova NUMERIC,
     p_data TIMESTAMP,
-    p_motivo TEXT,
-    p_user_id UUID
+    p_motivo TEXT
 ) RETURNS TABLE(id_ajuste INT) AS $$
 INSERT INTO ajuste_estoque(
     id_produto, quantidade_anterior, quantidade_nova, data_ajuste, motivo, user_id
 ) VALUES (
-    p_id_produto, p_quantidade_anterior, p_quantidade_nova, p_data, p_motivo, p_user_id
+    p_id_produto, p_quantidade_anterior, p_quantidade_nova, p_data, p_motivo, auth.uid()
 ) RETURNING id_ajuste;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_atualizar_fornecedor.sql
+++ b/db_init/functions/sp_atualizar_fornecedor.sql
@@ -4,8 +4,7 @@ CREATE OR REPLACE FUNCTION sp_atualizar_fornecedor(
     p_telefone TEXT,
     p_email TEXT,
     p_contato TEXT,
-    p_detalhes TEXT,
-    p_user_id UUID
+    p_detalhes TEXT
 ) RETURNS VOID AS $$
 UPDATE fornecedores
 SET nome = p_nome,
@@ -13,5 +12,5 @@ SET nome = p_nome,
     email = p_email,
     contato = p_contato,
     detalhes = p_detalhes
-WHERE id_fornecedor = p_id_fornecedor AND user_id = p_user_id;
+WHERE id_fornecedor = p_id_fornecedor AND user_id = auth.uid();
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_atualizar_status_pedido.sql
+++ b/db_init/functions/sp_atualizar_status_pedido.sql
@@ -1,9 +1,8 @@
 CREATE OR REPLACE FUNCTION sp_atualizar_status_pedido(
     p_id_pedido INT,
-    p_status TEXT,
-    p_user_id UUID
+    p_status TEXT
 ) RETURNS VOID AS $$
 UPDATE pedidos
 SET status_pedido = p_status
-WHERE id_pedido = p_id_pedido AND user_id = p_user_id;
+WHERE id_pedido = p_id_pedido AND user_id = auth.uid();
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_cadastrar_fornecedor.sql
+++ b/db_init/functions/sp_cadastrar_fornecedor.sql
@@ -3,10 +3,9 @@ CREATE OR REPLACE FUNCTION sp_cadastrar_fornecedor(
     p_telefone TEXT,
     p_email TEXT,
     p_contato TEXT,
-    p_detalhes TEXT,
-    p_user_id UUID
+    p_detalhes TEXT
 ) RETURNS TABLE(id_fornecedor INT) AS $$
 INSERT INTO fornecedores(nome, telefone, email, contato, detalhes, user_id)
-VALUES (p_nome, p_telefone, p_email, p_contato, p_detalhes, p_user_id)
+VALUES (p_nome, p_telefone, p_email, p_contato, p_detalhes, auth.uid())
 RETURNING id_fornecedor;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_cadastrar_producao_caseira.sql
+++ b/db_init/functions/sp_cadastrar_producao_caseira.sql
@@ -4,14 +4,13 @@ CREATE OR REPLACE FUNCTION sp_cadastrar_producao_caseira(
     p_unidade TEXT,
     p_tempo_preparo INT,
     p_data_inicio TIMESTAMP,
-    p_data_fim TIMESTAMP,
-    p_user_id UUID
+    p_data_fim TIMESTAMP
 ) RETURNS TABLE(id_producao INT) AS $$
 INSERT INTO producao_caseira(
     nome, quantidade_gerada, unidade_gerada, tempo_preparo,
     data_inicio_producao, data_fim_disponivel, user_id
 ) VALUES (
     p_nome, p_quantidade, p_unidade, p_tempo_preparo,
-    p_data_inicio, p_data_fim, p_user_id
+    p_data_inicio, p_data_fim, auth.uid()
 ) RETURNING id_producao;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_cadastrar_produto.sql
+++ b/db_init/functions/sp_cadastrar_produto.sql
@@ -3,14 +3,13 @@ CREATE OR REPLACE FUNCTION sp_cadastrar_produto(
     p_unidade_base TEXT,
     p_tipo_produto TEXT,
     p_controla_estoque BOOLEAN,
-    p_id_categoria INT,
-    p_user_id UUID
+    p_id_categoria INT
 ) RETURNS TABLE(id_produto INT) AS $$
 INSERT INTO produtos(
     nome, unidade_base, tipo_produto, controla_estoque,
     id_categoria, user_id
 ) VALUES (
     p_nome, p_unidade_base, p_tipo_produto, p_controla_estoque,
-    p_id_categoria, p_user_id
+    p_id_categoria, auth.uid()
 ) RETURNING id_produto;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_cadastrar_produto_venda.sql
+++ b/db_init/functions/sp_cadastrar_produto_venda.sql
@@ -2,12 +2,11 @@ CREATE OR REPLACE FUNCTION sp_cadastrar_produto_venda(
     p_id_produto INT,
     p_descricao_venda TEXT,
     p_quantidade_base NUMERIC,
-    p_preco_venda NUMERIC,
-    p_user_id UUID
+    p_preco_venda NUMERIC
 ) RETURNS TABLE(id_venda INT) AS $$
 INSERT INTO produtos_venda(
     id_produto, descricao_venda, quantidade_base, preco_venda, user_id
 ) VALUES (
-    p_id_produto, p_descricao_venda, p_quantidade_base, p_preco_venda, p_user_id
+    p_id_produto, p_descricao_venda, p_quantidade_base, p_preco_venda, auth.uid()
 ) RETURNING id_venda;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_cadastrar_receita.sql
+++ b/db_init/functions/sp_cadastrar_receita.sql
@@ -3,12 +3,11 @@ CREATE OR REPLACE FUNCTION sp_cadastrar_receita(
     p_tipo_receita TEXT,
     p_preco_venda NUMERIC,
     p_tempo_preparo INT,
-    p_id_categoria INT,
-    p_user_id UUID
+    p_id_categoria INT
 ) RETURNS TABLE(id_receita INT) AS $$
 INSERT INTO receitas(
     nome, tipo_receita, preco_venda, tempo_preparo_minutos, id_categoria, user_id
 ) VALUES (
-    p_nome, p_tipo_receita, p_preco_venda, p_tempo_preparo, p_id_categoria, p_user_id
+    p_nome, p_tipo_receita, p_preco_venda, p_tempo_preparo, p_id_categoria, auth.uid()
 ) RETURNING id_receita;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_cancelar_venda.sql
+++ b/db_init/functions/sp_cancelar_venda.sql
@@ -1,8 +1,7 @@
 CREATE OR REPLACE FUNCTION sp_cancelar_venda(
-    p_id_venda INT,
-    p_user_id UUID
+    p_id_venda INT
 ) RETURNS VOID AS $$
 UPDATE vendas
 SET cancelada = TRUE
-WHERE id_venda = p_id_venda AND user_id = p_user_id;
+WHERE id_venda = p_id_venda AND user_id = auth.uid();
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_criar_pedido.sql
+++ b/db_init/functions/sp_criar_pedido.sql
@@ -3,12 +3,11 @@ CREATE OR REPLACE FUNCTION sp_criar_pedido(
     p_id_mesa INT,
     p_nome_funcionario TEXT,
     p_data TIMESTAMP,
-    p_status TEXT,
-    p_user_id UUID
+    p_status TEXT
 ) RETURNS TABLE(id_pedido INT) AS $$
 INSERT INTO pedidos(
     id_venda, id_mesa, nome_funcionario, data_pedido, status_pedido, user_id
 ) VALUES (
-    p_id_venda, p_id_mesa, p_nome_funcionario, p_data, p_status, p_user_id
+    p_id_venda, p_id_mesa, p_nome_funcionario, p_data, p_status, auth.uid()
 ) RETURNING id_pedido;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_entrada_estoque.sql
+++ b/db_init/functions/sp_entrada_estoque.sql
@@ -2,12 +2,11 @@ CREATE OR REPLACE FUNCTION sp_entrada_estoque(
     p_id_produto INT,
     p_quantidade NUMERIC,
     p_data TIMESTAMP,
-    p_observacao TEXT,
-    p_user_id UUID
+    p_observacao TEXT
 ) RETURNS TABLE(id_entrada INT) AS $$
 INSERT INTO entrada_estoque(
     id_produto, quantidade_entrada, data_entrada, observacao, user_id
 ) VALUES (
-    p_id_produto, p_quantidade, p_data, p_observacao, p_user_id
+    p_id_produto, p_quantidade, p_data, p_observacao, auth.uid()
 ) RETURNING id_entrada;
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_fechar_venda.sql
+++ b/db_init/functions/sp_fechar_venda.sql
@@ -1,9 +1,8 @@
 CREATE OR REPLACE FUNCTION sp_fechar_venda(
     p_id_venda INT,
-    p_data TIMESTAMP,
-    p_user_id UUID
+    p_data TIMESTAMP
 ) RETURNS VOID AS $$
 UPDATE vendas
 SET status_aberta = FALSE
-WHERE id_venda = p_id_venda AND user_id = p_user_id;
+WHERE id_venda = p_id_venda AND user_id = auth.uid();
 $$ LANGUAGE SQL;

--- a/db_init/functions/sp_registrar_mesa.sql
+++ b/db_init/functions/sp_registrar_mesa.sql
@@ -2,12 +2,11 @@ CREATE OR REPLACE FUNCTION sp_registrar_mesa(
     p_numero INT,
     p_quantidade_lugares INT,
     p_status BOOLEAN,
-    p_nome_cliente TEXT,
-    p_user_id UUID
+    p_nome_cliente TEXT
 ) RETURNS TABLE(id_mesa INT) AS $$
 INSERT INTO mesas(
     numero_mesa, quantidade_lugares, status_ocupada, nome_cliente, user_id
 ) VALUES (
-    p_numero, p_quantidade_lugares, p_status, p_nome_cliente, p_user_id
+    p_numero, p_quantidade_lugares, p_status, p_nome_cliente, auth.uid()
 ) RETURNING id_mesa;
 $$ LANGUAGE SQL;

--- a/db_init/tables/rls_policies.sql
+++ b/db_init/tables/rls_policies.sql
@@ -1,0 +1,50 @@
+-- Row Level Security policies for BotecoPro tables
+
+-- Enable RLS and restrict access by user_id for all tables
+ALTER TABLE fornecedores ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_fornecedores ON fornecedores USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE categorias ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_categorias ON categorias USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE produtos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_produtos ON produtos USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE produtos_venda ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_produtos_venda ON produtos_venda USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE receitas ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_receitas ON receitas USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE receita_ingredientes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_receita_ingredientes ON receita_ingredientes USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE producao_caseira ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_producao_caseira ON producao_caseira USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE producao_ingredientes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_producao_ingredientes ON producao_ingredientes USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE estoque ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_estoque ON estoque USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE entrada_estoque ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_entrada_estoque ON entrada_estoque USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE ajuste_estoque ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_ajuste_estoque ON ajuste_estoque USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE consumo_interno ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_consumo_interno ON consumo_interno USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE mesas ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_mesas ON mesas USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE vendas ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_vendas ON vendas USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE pedidos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_pedidos ON pedidos USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE pedido_itens ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p_pedido_itens ON pedido_itens USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- implement row level security policies for all tables
- enforce `auth.uid()` inside stored procedures
- test schema, policies, views and procedures using local PostgreSQL

## Testing
- `service postgresql start`
- `psql -U boteco -d boteco_dev -h localhost -f db_init/tables/schema.sql`
- `psql -U boteco -d boteco_dev -h localhost -f db_init/tables/rls_policies.sql`
- `for f in db_init/functions/*.sql; do psql -U boteco -d boteco_dev -h localhost -f $f; done`
- `for f in db_init/views/*.sql; do psql -U boteco -d boteco_dev -h localhost -f $f; done`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6889325d7a808322b3ef0331fb9e98eb