### PR TITLE
Update Postgres init workflow

### DIFF
--- a/scripts/init_postgres.sh
+++ b/scripts/init_postgres.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SEED=0
+if [[ "${1:-}" == "--seed" ]]; then
+  SEED=1
+fi
+
 # Ensure Postgres container is running
 if command -v docker compose &>/dev/null; then
   docker compose up -d db
@@ -17,6 +22,13 @@ until docker exec "$CONTAINER_ID" pg_isready -U "${POSTGRES_USER:-boteco}" >/dev
 done
 
 # Load schema
-cat database/postgres/schema.sql | docker exec -i "$CONTAINER_ID" psql -U "${POSTGRES_USER:-boteco}" -d "${POSTGRES_DB:-boteco_dev}"
+cat supabase/tables/schema.sql | docker exec -i "$CONTAINER_ID" psql -U "${POSTGRES_USER:-boteco}" -d "${POSTGRES_DB:-boteco_dev}"
+
+# Apply RLS policies
+cat supabase/tables/rls_policies.sql | docker exec -i "$CONTAINER_ID" psql -U "${POSTGRES_USER:-boteco}" -d "${POSTGRES_DB:-boteco_dev}"
+
+if [[ "$SEED" -eq 1 ]]; then
+  cat supabase/tables/seed.sql | docker exec -i "$CONTAINER_ID" psql -U "${POSTGRES_USER:-boteco}" -d "${POSTGRES_DB:-boteco_dev}"
+fi
 
 echo "✅ Database initialized"

--- a/supabase/tables/schema.sql
+++ b/supabase/tables/schema.sql
@@ -164,25 +164,3 @@ CREATE TABLE IF NOT EXISTS pedido_itens (
     observacao TEXT,
     user_id UUID REFERENCES auth.users(id)
 );
-
--- Sample seed data ---------------------------------------------------------
-INSERT INTO auth.users(id,email) VALUES
-    ('00000000-0000-0000-0000-000000000001','demo@boteco.local')
-    ON CONFLICT DO NOTHING;
-
--- Insert sample categories
-INSERT INTO categorias (nome, descricao, user_id) VALUES
-    ('Bebidas', 'Bebidas em geral', '00000000-0000-0000-0000-000000000001'),
-    ('Comidas', 'Alimentos em geral', '00000000-0000-0000-0000-000000000001'),
-    ('Outros', 'Produtos diversos', '00000000-0000-0000-0000-000000000001')
-    ON CONFLICT DO NOTHING;
-
--- Insert sample tables
-DO $$
-BEGIN
-    FOR i IN 1..10 LOOP
-        INSERT INTO mesas(numero_mesa, quantidade_lugares, status_ocupada, user_id)
-        VALUES(i, (i % 3) + 2, FALSE, '00000000-0000-0000-0000-000000000001')
-        ON CONFLICT DO NOTHING;
-    END LOOP;
-END$$;

--- a/supabase/tables/seed.sql
+++ b/supabase/tables/seed.sql
@@ -1,0 +1,21 @@
+-- Sample seed data ---------------------------------------------------------
+INSERT INTO auth.users(id,email) VALUES
+    ('00000000-0000-0000-0000-000000000001','demo@boteco.local')
+    ON CONFLICT DO NOTHING;
+
+-- Insert sample categories
+INSERT INTO categorias (nome, descricao, user_id) VALUES
+    ('Bebidas', 'Bebidas em geral', '00000000-0000-0000-0000-000000000001'),
+    ('Comidas', 'Alimentos em geral', '00000000-0000-0000-0000-000000000001'),
+    ('Outros', 'Produtos diversos', '00000000-0000-0000-0000-000000000001')
+    ON CONFLICT DO NOTHING;
+
+-- Insert sample tables
+DO $$
+BEGIN
+    FOR i IN 1..10 LOOP
+        INSERT INTO mesas(numero_mesa, quantidade_lugares, status_ocupada, user_id)
+        VALUES(i, (i % 3) + 2, FALSE, '00000000-0000-0000-0000-000000000001')
+        ON CONFLICT DO NOTHING;
+    END LOOP;
+END$$;


### PR DESCRIPTION
## Summary
- load schema from new supabase location
- apply RLS policies after loading schema
- move demo inserts to separate optional seed script
- add `--seed` flag to `init_postgres.sh`

## Testing
- `flutter test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688baeb08f548322b48e4ef5af658473