### PR TITLE
Fix auth wrapper and remove test credentials

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,8 +66,7 @@ class MyApp extends StatelessWidget {
         darkTheme: darkTheme,
         themeMode: themeProvider.themeMode,
         debugShowCheckedModeBanner: false,
-        // home: AuthWrapper(init: init, child: const MainNavigationScreen()),
-        home: home);
+        home: AuthWrapper(init: init, child: home));
   }
 }
 

--- a/lib/pages/auth/login_page.dart
+++ b/lib/pages/auth/login_page.dart
@@ -23,9 +23,6 @@ class _LoginPageState extends State<LoginPage> {
   @override
   void initState() {
     super.initState();
-    // Pre-fill with test account
-    _emailController.text = 'admin@boteco.pro';
-    _passwordController.text = 'admin123';
   }
 
   @override


### PR DESCRIPTION
## Summary
- enable `AuthWrapper` in `MyApp` so unauthenticated users go to Login
- remove preset email/password from Login page

## Testing
- `flutter analyze --no-pub` *(fails: issues found)*
- `flutter test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688c7b3194d48322a90fa7573ed3b43d