### PR TITLE
Remove adapter defaults

### DIFF
--- a/lib/adapters/model_adapters.dart
+++ b/lib/adapters/model_adapters.dart
@@ -212,14 +212,18 @@ class ProductionIngredientAdapter {
 }
 
 class ProductAdapter {
-  static Produto toProduto(Product product) {
+  static Produto toProduto(
+    Product product, {
+    required String tipoProduto,
+    required int idCategoria,
+  }) {
     return Produto(
       id_produto: int.tryParse(product.id),
       nome: product.name,
       unidade_base: product.unit,
-      tipo_produto: 'compra', // Default value
+      tipo_produto: tipoProduto,
       controla_estoque: true,
-      id_categoria: 1, // Default category
+      id_categoria: idCategoria,
     );
   }
 

--- a/lib/services/service_provider.dart
+++ b/lib/services/service_provider.dart
@@ -284,7 +284,6 @@ class ServiceProvider with ChangeNotifier {
   }
 
   // PRODUÇÕES CASEIRAS (In-house Productions)
-  // TODO: implementar usando Supabase
   Future<List<ProducaoCaseira>> getProducoes() async {
     return await _supabaseService.getProducoes();
   }


### PR DESCRIPTION
## Summary
- drop hardcoded defaults for product type and category in `ProductAdapter`
- remove outdated TODO about Supabase in `ServiceProvider`
- verify updateProduto updates `produtos_venda` via RPC

## Testing
- `flutter analyze`
- `flutter test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_688cda7a73fc83228d0ea909001fb8d9