### PR TITLE
Add basic auth provider tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Analyze
         run: flutter analyze
       - name: Run tests
-        run: flutter test --coverage
+        run: |
+          set -e
+          flutter test --coverage
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -7,14 +7,15 @@ import '../l10n/app_localizations.dart';
 enum AuthStatus { initial, authenticated, unauthenticated }
 
 class AuthProvider with ChangeNotifier {
-  final SupabaseAuthService _authService = SupabaseAuthService();
+  final SupabaseAuthService _authService;
   AuthStatus _status = AuthStatus.initial;
   AuthUser? _user;
   String? _error;
   bool _isLoading = false;
 
   // Constructor
-  AuthProvider() {
+  AuthProvider({SupabaseAuthService? authService})
+      : _authService = authService ?? SupabaseAuthService() {
     _initializeAuth();
   }
 

--- a/lib/services/supabase_database_service.dart
+++ b/lib/services/supabase_database_service.dart
@@ -6,13 +6,30 @@ import '../models/data_models.dart';
 class SupabaseDatabaseService {
   static final SupabaseDatabaseService _instance =
       SupabaseDatabaseService._internal();
-  factory SupabaseDatabaseService() => _instance;
+
+  factory SupabaseDatabaseService({
+    supabase.SupabaseClient? client,
+    String? userId,
+  }) {
+    if (client != null) {
+      _instance._client = client;
+    }
+    if (userId != null) {
+      _instance._overrideUserId = userId;
+    }
+    return _instance;
+  }
+
   SupabaseDatabaseService._internal();
 
-  final supabase.SupabaseClient _supabase = supabase.Supabase.instance.client;
+  supabase.SupabaseClient? _client;
+  String? _overrideUserId;
+
+  supabase.SupabaseClient get _supabase =>
+      _client ??= supabase.Supabase.instance.client;
 
   // Current user ID for row-level security
-  String? get _userId => _supabase.auth.currentUser?.id;
+  String? get _userId => _overrideUserId ?? _supabase.auth.currentUser?.id;
 
   // Initialize data. Sample data can optionally be created for empty accounts
   Future<void> initializeData({bool createSampleData = false}) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -701,6 +701,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.0
 
+  mocktail: ^1.0.0
+
   supabase: any
 flutter:
   uses-material-design: true

--- a/test/auth_provider_test.dart
+++ b/test/auth_provider_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:boteco_pro/providers/auth_provider.dart';
+import 'package:boteco_pro/services/supabase_auth_service.dart';
+import 'package:boteco_pro/models/auth_user.dart';
+
+class MockAuthService extends Mock implements SupabaseAuthService {}
+
+class FakeBuildContext extends Fake implements BuildContext {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(FakeBuildContext());
+    registerFallbackValue(Exception('error'));
+  });
+
+  group('AuthProvider', () {
+    late MockAuthService authService;
+    late AuthProvider provider;
+    late BuildContext ctx;
+
+    setUp(() async {
+      authService = MockAuthService();
+      when(() => authService.authStateChanges)
+          .thenAnswer((_) => const Stream.empty());
+      when(() => authService.currentUser).thenReturn(null);
+      provider = AuthProvider(authService: authService);
+    });
+
+    Future<void> _setupContext(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            ctx = context;
+            return const SizedBox.shrink();
+          }),
+        ),
+      );
+    }
+
+    testWidgets('signInWithEmail returns true on success', (tester) async {
+      final user = AuthUser(uid: '1', email: 'test@test.com');
+      when(() => authService.signInWithEmail('test@test.com', 'pass'))
+          .thenAnswer((_) async => user);
+
+      await _setupContext(tester);
+
+      final result =
+          await provider.signInWithEmail(ctx, 'test@test.com', 'pass');
+
+      expect(result, isTrue);
+      verify(() => authService.signInWithEmail('test@test.com', 'pass'))
+          .called(1);
+    });
+
+    testWidgets('signUpWithEmail returns true on success', (tester) async {
+      final user = AuthUser(uid: '2', email: 'new@test.com');
+      when(() => authService.signUpWithEmail('new@test.com', 'pass', 'Name'))
+          .thenAnswer((_) async => user);
+
+      await _setupContext(tester);
+
+      final result =
+          await provider.signUpWithEmail(ctx, 'new@test.com', 'pass', 'Name');
+
+      expect(result, isTrue);
+      verify(() => authService.signUpWithEmail('new@test.com', 'pass', 'Name'))
+          .called(1);
+    });
+
+    testWidgets('signInWithEmail handles error', (tester) async {
+      when(() => authService.signInWithEmail('bad@test.com', 'pass'))
+          .thenThrow(Exception('user-not-found'));
+      when(() => authService.getMessageFromErrorCode(any(), any()))
+          .thenReturn('User not found');
+
+      await _setupContext(tester);
+
+      final result =
+          await provider.signInWithEmail(ctx, 'bad@test.com', 'pass');
+
+      expect(result, isFalse);
+      expect(provider.error, 'User not found');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- inject auth service for easier mocking
- allow injecting Supabase client and userId into database service
- add mocktail as dev dependency
- add unit tests for `AuthProvider`
- fail CI fast on test errors

## Testing
- `flutter analyze`
- `flutter test -j 1`


------
https://chatgpt.com/codex/tasks/task_e_688cda9e0ccc8322ac540890e7d8dc74