### PR TITLE
Add database indexes and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@ It helps owners keep tables, orders, stock, recipes and in-house production unde
    ```bash
    docker compose up -d
    ```
-4. Aplique o esquema inicial executando `./scripts/init_postgres.sh` (use `--seed` caso queira gerar dados de exemplo). Este script carrega o schema e aplica as políticas de segurança definidas em `supabase/tables/rls_policies.sql`. Caso prefira gerar esses dados ao iniciar o app, defina `CREATE_SAMPLE_DATA=true` no `.env`.
-5. Se estiver utilizando o Supabase CLI, execute `supabase db push` e certifique-se de incluir o arquivo `supabase/tables/rls_policies.sql` (já disponível em `supabase/migrations`) para que as políticas RLS sejam criadas no projeto remoto.
+4. Inicialize o banco rodando:
+   ```bash
+   ./scripts/init_postgres.sh --seed
+   ```
+   O script carrega `schema.sql`, aplica as políticas de **Row Level Security** definidas em `supabase/tables/rls_policies.sql` e popula dados de exemplo.
+   Caso prefira gerar esses dados ao iniciar o app, defina `CREATE_SAMPLE_DATA=true` no `.env`.
+5. Se estiver utilizando o Supabase CLI, execute `supabase db push`. O comando aplicará todos os arquivos presentes em `supabase/migrations`, incluindo `rls_policies.sql` e as migrações mais recentes.
 6. Execute o aplicativo normalmente com `flutter run`.
    Para rodar a versão web use `flutter run -d chrome`. Caso o navegador
    não esteja disponível (como em ambientes de CI ou containers

--- a/supabase/migrations/20240101000002_add_indexes.sql
+++ b/supabase/migrations/20240101000002_add_indexes.sql
@@ -1,0 +1,4 @@
+-- Indexes to improve common queries
+CREATE INDEX IF NOT EXISTS idx_produtos_id_categoria ON produtos(id_categoria);
+CREATE INDEX IF NOT EXISTS idx_pedidos_id_mesa ON pedidos(id_mesa);
+CREATE INDEX IF NOT EXISTS idx_vendas_data_venda ON vendas(data_venda);


### PR DESCRIPTION
## Summary
- document how to seed the local Postgres database
- note that `supabase db push` will apply `rls_policies.sql` and new migrations
- add migration with indexes for common queries

## Testing
- `supabase db push` *(fails: Cannot find project ref)*
- `flutter analyze --no-pub` *(fails: many issues)*
- `flutter test --coverage` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d197bb9a4832281103de882324b01