### PR TITLE
Localize settings page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -59,6 +59,8 @@
   "about": "About",
   "appVersion": "App version",
   "aboutBoteco": "About Boteco PRO",
+  "aboutBotecoDescription": "Boteco PRO is a complete management system for bars and restaurants. Manage tables, products, suppliers, stocks and much more.",
+  "aboutBotecoRights": "© 2023 Boteco PRO\nAll rights reserved",
   "infoLicenses": "Information and licenses",
   "logoutSystem": "Log out",
   "logoutApp": "Log out of the app",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -59,6 +59,8 @@
   "about": "About",
   "appVersion": "App version",
   "aboutBoteco": "About Boteco PRO",
+  "aboutBotecoDescription": "Boteco PRO es un sistema de gestión completo para bares y restaurantes. Administra mesas, productos, proveedores, existencias y mucho más.",
+  "aboutBotecoRights": "© 2023 Boteco PRO\nTodos los derechos reservados",
   "infoLicenses": "Information and licenses",
   "logoutSystem": "Log out",
   "logoutApp": "Log out of the app",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -59,6 +59,8 @@
   "about": "About",
   "appVersion": "App version",
   "aboutBoteco": "About Boteco PRO",
+  "aboutBotecoDescription": "Boteco PRO est un système de gestion complet pour les bars et restaurants. Gérez les tables, produits, fournisseurs, stocks et bien plus encore.",
+  "aboutBotecoRights": "© 2023 Boteco PRO\nTous droits réservés",
   "infoLicenses": "Information and licenses",
   "logoutSystem": "Log out",
   "logoutApp": "Log out of the app",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -65,7 +65,7 @@ import 'app_localizations_pt.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -88,18 +88,18 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
     Locale('pt'),
     Locale('es'),
-    Locale('fr')
+    Locale('fr'),
   ];
 
   /// No description provided for @appName.
@@ -455,6 +455,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'About Boteco PRO'**
   String get aboutBoteco;
+
+  /// No description provided for @aboutBotecoDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Boteco PRO is a complete management system for bars and restaurants. Manage tables, products, suppliers, stocks and much more.'**
+  String get aboutBotecoDescription;
+
+  /// No description provided for @aboutBotecoRights.
+  ///
+  /// In en, this message translates to:
+  /// **'© 2023 Boteco PRO\nAll rights reserved'**
+  String get aboutBotecoRights;
 
   /// No description provided for @infoLicenses.
   ///
@@ -1040,8 +1052,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -189,6 +189,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aboutBoteco => 'About Boteco PRO';
 
   @override
+  String get aboutBotecoDescription =>
+      'Boteco PRO is a complete management system for bars and restaurants. Manage tables, products, suppliers, stocks and much more.';
+
+  @override
+  String get aboutBotecoRights => '© 2023 Boteco PRO\nAll rights reserved';
+
+  @override
   String get infoLicenses => 'Information and licenses';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -189,6 +189,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aboutBoteco => 'About Boteco PRO';
 
   @override
+  String get aboutBotecoDescription =>
+      'Boteco PRO es un sistema de gestión completo para bares y restaurantes. Administra mesas, productos, proveedores, existencias y mucho más.';
+
+  @override
+  String get aboutBotecoRights =>
+      '© 2023 Boteco PRO\nTodos los derechos reservados';
+
+  @override
   String get infoLicenses => 'Information and licenses';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -189,6 +189,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aboutBoteco => 'About Boteco PRO';
 
   @override
+  String get aboutBotecoDescription =>
+      'Boteco PRO est un système de gestion complet pour les bars et restaurants. Gérez les tables, produits, fournisseurs, stocks et bien plus encore.';
+
+  @override
+  String get aboutBotecoRights => '© 2023 Boteco PRO\nTous droits réservés';
+
+  @override
   String get infoLicenses => 'Information and licenses';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -189,6 +189,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get aboutBoteco => 'Sobre o Boteco PRO';
 
   @override
+  String get aboutBotecoDescription =>
+      'Boteco PRO é um sistema de gestão completo para bares e restaurantes. Gerencie mesas, produtos, fornecedores, estoques e muito mais.';
+
+  @override
+  String get aboutBotecoRights =>
+      '© 2023 Boteco PRO\nTodos os direitos reservados';
+
+  @override
   String get infoLicenses => 'Informações e licenças';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -59,6 +59,8 @@
   "about": "Sobre",
   "appVersion": "Versão do aplicativo",
   "aboutBoteco": "Sobre o Boteco PRO",
+  "aboutBotecoDescription": "Boteco PRO é um sistema de gestão completo para bares e restaurantes. Gerencie mesas, produtos, fornecedores, estoques e muito mais.",
+  "aboutBotecoRights": "© 2023 Boteco PRO\nTodos os direitos reservados",
   "infoLicenses": "Informações e licenças",
   "logoutSystem": "Sair do Sistema",
   "logoutApp": "Sair do aplicativo",

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -48,7 +48,7 @@ class _SettingsPageState extends State<SettingsPage> {
           const SizedBox(height: 24),
           _buildSection(
             context: context,
-            title: 'Aparência',
+            title: context.l10n.appearance,
             icon: Icons.palette,
             children: [
               _buildThemeSettings(context, themeProvider),
@@ -57,7 +57,7 @@ class _SettingsPageState extends State<SettingsPage> {
           const SizedBox(height: 24),
           _buildSection(
             context: context,
-            title: 'Sincronização',
+            title: context.l10n.sync,
             icon: Icons.sync,
             children: [
               _buildSyncSettings(context, serviceProvider),
@@ -66,7 +66,7 @@ class _SettingsPageState extends State<SettingsPage> {
           const SizedBox(height: 24),
           _buildSection(
             context: context,
-            title: 'Notificações',
+            title: context.l10n.notifications,
             icon: Icons.notifications,
             children: [
               SwitchListTile(
@@ -122,7 +122,7 @@ class _SettingsPageState extends State<SettingsPage> {
             children: [
               ListTile(
                 title: Text(context.l10n.appVersion),
-                subtitle: Text('1.0.0'),
+                subtitle: Text(context.l10n.appVersionNumber),
                 trailing: const Icon(Icons.check_circle, color: Colors.green),
               ),
               ListTile(
@@ -138,9 +138,9 @@ class _SettingsPageState extends State<SettingsPage> {
             child: OutlinedButton.icon(
               onPressed: () => _showLogoutConfirmation(context),
               icon: const Icon(Icons.logout, color: Colors.red),
-              label: const Text(
-                'Sair do Sistema',
-                style: TextStyle(color: Colors.red),
+              label: Text(
+                context.l10n.logoutSystemLabel,
+                style: const TextStyle(color: Colors.red),
               ),
               style: OutlinedButton.styleFrom(
                 side: const BorderSide(color: Colors.red),
@@ -344,34 +344,34 @@ class _SettingsPageState extends State<SettingsPage> {
             children: [
               TextField(
                 controller: nameController,
-                decoration: const InputDecoration(
-                  labelText: 'Nome',
-                  prefixIcon: Icon(Icons.person),
+                decoration: InputDecoration(
+                  labelText: context.l10n.nameLabel,
+                  prefixIcon: const Icon(Icons.person),
                 ),
               ),
               const SizedBox(height: 16),
               TextField(
                 controller: emailController,
-                decoration: const InputDecoration(
-                  labelText: 'Email',
-                  prefixIcon: Icon(Icons.email),
+                decoration: InputDecoration(
+                  labelText: context.l10n.emailLabel,
+                  prefixIcon: const Icon(Icons.email),
                 ),
                 keyboardType: TextInputType.emailAddress,
               ),
               const SizedBox(height: 16),
               TextField(
                 controller: establishmentController,
-                decoration: const InputDecoration(
-                  labelText: 'Estabelecimento',
-                  prefixIcon: Icon(Icons.business),
+                decoration: InputDecoration(
+                  labelText: context.l10n.establishment,
+                  prefixIcon: const Icon(Icons.business),
                 ),
               ),
               const SizedBox(height: 16),
               TextField(
                 controller: positionController,
-                decoration: const InputDecoration(
-                  labelText: 'Cargo',
-                  prefixIcon: Icon(Icons.badge),
+                decoration: InputDecoration(
+                  labelText: context.l10n.position,
+                  prefixIcon: const Icon(Icons.badge),
                 ),
               ),
             ],
@@ -475,22 +475,21 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
             ),
             const SizedBox(height: 16),
-            const Text(
-              'Boteco PRO',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            Text(
+              context.l10n.appName,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
             Text('${context.l10n.appVersion} ${context.l10n.appVersionNumber}'),
             const SizedBox(height: 16),
-            const Text(
-              'Boteco PRO é um sistema de gestão completo para bares e restaurantes. '
-              'Gerencie mesas, produtos, fornecedores, estoques e muito mais.',
+            Text(
+              context.l10n.aboutBotecoDescription,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 16),
-            const Text(
-              '© 2023 Boteco PRO\nTodos os direitos reservados',
+            Text(
+              context.l10n.aboutBotecoRights,
               textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 12),
+              style: const TextStyle(fontSize: 12),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- add about dialog strings to translation files
- wire up `settings_page.dart` to use localized strings
- regenerate localization sources

## Testing
- `flutter analyze --no-pub` *(fails: undefined classes)*
- `flutter test --coverage` *(fails: Supabase auth error)*

------
https://chatgpt.com/codex/tasks/task_e_688d19efc514832299aecea12b5ca376