### PR TITLE
Add Nixpacks configuration for Flutter web deployment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "BotecoPro Flutter workspace";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            flutter
+            python3
+            pkg-config
+            git
+            which
+            unzip
+            curl
+            openssl
+          ];
+
+          shellHook = ''
+            export FLUTTER_ROOT=${pkgs.flutter}/share/flutter
+            export PATH="$FLUTTER_ROOT/bin:$PATH"
+            flutter config --enable-web >/dev/null 2>&1 || true
+          '';
+        };
+      }
+    );
+}

--- a/lib/services/sound_service.dart
+++ b/lib/services/sound_service.dart
@@ -13,24 +13,28 @@ class SoundService {
   bool _soundEnabled = true;
   
   // Audio cache to preload sounds
-  final cache = AudioCache(prefix: 'assets/sounds/');
+  final AudioCache _cache = AudioCache(prefix: 'assets/sounds/');
+
+  static const List<String> _soundEffectNames = [
+    'mesa_aberta',
+    'mesa_fechada',
+    'pedido_adicionado',
+    'pedido_entregue',
+    'venda_fechada',
+    'produto_adicionado',
+    'sucesso',
+    'erro',
+    'notificacao',
+    'navegacao',
+  ];
   
   // Initialize sound service
   Future<void> init() async {
     await _loadSoundPreference();
     // Preload all sounds
-    await Future.wait([
-      cache.loadAsset('mesa_aberta.mp3'),
-      cache.loadAsset('mesa_fechada.mp3'),
-      cache.loadAsset('pedido_adicionado.mp3'),
-      cache.loadAsset('pedido_entregue.mp3'),
-      cache.loadAsset('venda_fechada.mp3'),
-      cache.loadAsset('produto_adicionado.mp3'),
-      cache.loadAsset('sucesso.mp3'),
-      cache.loadAsset('erro.mp3'),
-      cache.loadAsset('notificacao.mp3'),
-      cache.loadAsset('navegacao.mp3'),
-    ]);
+    await _cache.loadAll(
+      _soundEffectNames.map((name) => '$name.mp3').toList(),
+    );
   }
   
   Future<void> _loadSoundPreference() async {

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,33 @@
+providers = ["nix"]
+
+[phases.setup]
+nixPkgs = [
+  "bash",
+  "coreutils",
+  "curl",
+  "flutter",
+  "git",
+  "pkg-config",
+  "python3",
+  "unzip",
+  "which"
+]
+
+[phases.install]
+commands = [
+  "flutter config --enable-web",
+  "flutter pub get"
+]
+
+[phases.build]
+dependsOn = ["install"]
+commands = [
+  "flutter build web --release"
+]
+artifactPaths = ["build/web"]
+
+[start]
+cmd = "python3 -m http.server ${PORT:-8080} --directory build/web"
+
+[variables]
+PORT = "8080"


### PR DESCRIPTION
## Summary
- add a nixpacks configuration that installs flutter, builds the web release, and serves the compiled assets
- define a Nix flake dev shell so contributors get a consistent Flutter toolchain when using Nix
- update the sound service preload logic to use AudioCache.loadAll instead of the testing-only API

## Testing
- flutter test *(fails: Supabase integration test needs credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68f21f45b9b083229c3534f57276b66a