### PR TITLE
Add Nixpacks configuration for Flutter web builds

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,29 @@
+[environment]
+FLUTTER_SUPPRESS_ANALYTICS = "true"
+CI = "true"
+
+[phases.setup]
+aptPkgs = ["curl", "git", "unzip", "xz-utils", "python3", "ca-certificates"]
+commands = [
+  "curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.24.3-stable.tar.xz -o /tmp/flutter.tar.xz",
+  "mkdir -p /opt",
+  "tar -xf /tmp/flutter.tar.xz -C /opt",
+  "ln -sf /opt/flutter/bin/flutter /usr/local/bin/flutter",
+  "ln -sf /opt/flutter/bin/dart /usr/local/bin/dart",
+  "rm -f /tmp/flutter.tar.xz",
+  "flutter config --enable-web",
+  "flutter precache --web"
+]
+
+[phases.install]
+commands = [
+  "flutter pub get"
+]
+
+[phases.build]
+commands = [
+  "flutter build web --release"
+]
+
+[start]
+cmd = "python3 -m http.server ${PORT:-8080} --directory build/web"


### PR DESCRIPTION
## Summary
- add a custom `nixpacks.toml` so deployments install the Flutter SDK, run Flutter build steps, and serve the web bundle

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f8c257a3a08322a6aa2757428f3116