### PR TITLE
Fix Portuguese orthography across UI and config

### DIFF
--- a/lib/pages/order_details_page.dart
+++ b/lib/pages/order_details_page.dart
@@ -842,7 +842,7 @@ class _OrderDetailsPageState extends State<OrderDetailsPage> {
                         children: const [
                           Icon(Icons.credit_card),
                           SizedBox(width: 8),
-                          Text('Cartão de Cru00e9dito'),
+                          Text('Cartão de Crédito'),
                         ],
                       ),
                     ),
@@ -852,7 +852,7 @@ class _OrderDetailsPageState extends State<OrderDetailsPage> {
                         children: const [
                           Icon(Icons.credit_card),
                           SizedBox(width: 8),
-                          Text('Cartão de Du00e9bito'),
+                          Text('Cartão de Débito'),
                         ],
                       ),
                     ),

--- a/lib/pages/production_page.dart
+++ b/lib/pages/production_page.dart
@@ -305,7 +305,7 @@ class _ProductionPageState extends State<ProductionPage> {
                     controller: nameController,
                     decoration: const InputDecoration(
                       labelText: 'Nome do Produto*',
-                      hintText: 'Ex: Cachau00e7a de Abacaxi, Bolinho Caseiro...',
+                      hintText: 'Ex: Cachaça de Abacaxi, Bolinho Caseiro...',
                     ),
                   ),
                   const SizedBox(height: 16),
@@ -367,7 +367,7 @@ class _ProductionPageState extends State<ProductionPage> {
                   TextField(
                     controller: notesController,
                     decoration: const InputDecoration(
-                      labelText: 'Observaçu00f5es',
+                      labelText: 'Observações',
                     ),
                     maxLines: 3,
                   ),
@@ -528,7 +528,7 @@ class _ProductionPageState extends State<ProductionPage> {
                   TextField(
                     controller: notesController,
                     decoration: const InputDecoration(
-                      labelText: 'Observaçu00f5es',
+                      labelText: 'Observações',
                     ),
                     maxLines: 3,
                   ),
@@ -940,7 +940,7 @@ class _ProductionPageState extends State<ProductionPage> {
             if (production.notes.isNotEmpty) ...[  
               const SizedBox(height: 16),
               const Text(
-                'Observaçu00f5es:',
+                'Observações:',
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 8),

--- a/lib/pages/suppliers_page.dart
+++ b/lib/pages/suppliers_page.dart
@@ -262,7 +262,7 @@ class _SuppliersPageState extends State<SuppliersPage> {
               TextField(
                 controller: notesController,
                 decoration: const InputDecoration(
-                  labelText: 'Observaçu00f5es',
+                  labelText: 'Observações',
                   hintText: 'Ex: Entrega às segundas',
                 ),
                 maxLines: 3,
@@ -371,7 +371,7 @@ class _SuppliersPageState extends State<SuppliersPage> {
               TextField(
                 controller: notesController,
                 decoration: const InputDecoration(
-                  labelText: 'Observaçu00f5es',
+                  labelText: 'Observações',
                 ),
                 maxLines: 3,
               ),
@@ -454,7 +454,7 @@ class _SuppliersPageState extends State<SuppliersPage> {
             _loadSuppliers();
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text('Fornecedor ${supplier.name} excluu00eddo'),
+                content: Text('Fornecedor ${supplier.name} excluído'),
                 backgroundColor: Colors.red,
               ),
             );

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -366,7 +366,7 @@ class DatabaseService {
     await saveSales(sales);
   }
 
-  // Métodos para consultas especu00edficas
+  // Métodos para consultas específicas
   Future<Order?> getActiveOrderForTable(String tableId) async {
     final orders = await getOrders();
     try {
@@ -446,7 +446,7 @@ class DatabaseService {
     }
   }
 
-  // Métodos para Produçu00f5es Caseiras
+  // Métodos para Produções Caseiras
   Future<List<InternalProduction>> getInternalProductions() async {
     final prefs = await SharedPreferences.getInstance();
     final productionsJson = prefs.getStringList(_productionsKey) ?? [];

--- a/lib/widgets/bottom_navigation.dart
+++ b/lib/widgets/bottom_navigation.dart
@@ -40,7 +40,7 @@ class BottomNavigation extends StatelessWidget {
         BottomNavigationBarItem(
           icon: Icon(Icons.home_outlined),
           activeIcon: Icon(Icons.home),
-          label: 'Inu00edcio',
+          label: 'Início',
         ),
         BottomNavigationBarItem(
           icon: Icon(Icons.table_bar_outlined),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: botecoPro
+name: boteco_pro
 description: "Gestão completa para seu bar"
 publish_to: 'none'
 version: 1.0.0
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   flutter_animate: ^4.0.0
-  flutter_launcher_icons: 0.14.3
+  flutter_launcher_icons: ^0.14.3
   table_calendar: ^3.0.0
   flutter_slidable: ^3.0.0
   flutter_svg: ^2.0.0
@@ -16,11 +16,11 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.0
-  fl_chart: 0.68.0
-  shared_preferences: 2.3.2
-  provider: 6.1.2
-  http: '>=1.0.0'
-  uuid: '>=3.0.0'
+  fl_chart: ^0.68.0
+  shared_preferences: ^2.3.2
+  provider: ^6.1.2
+  http: ^1.0.0
+  uuid: ^3.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- restore proper Portuguese accents in navigation, payment, supplier, and production labels
- correct comments in the database service to use proper accented words
- fix the package metadata name and dependency specifications in pubspec.yaml

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8ef72f8f48322a40cda6827fef613