### PR TITLE
fix: clamp stock when closing orders

### DIFF
--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -56,6 +56,7 @@
 ///
 
 import 'dart:convert';
+import 'dart:math';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/data_models.dart';
 
@@ -379,8 +380,9 @@ class DatabaseService {
             products.indexWhere((p) => p.id == item.productId);
         if (productIndex != -1) {
           final currentStock = products[productIndex].stockQuantity;
-          products[productIndex] = products[productIndex]
-              .copyWith(stockQuantity: currentStock - item.quantity);
+          final updatedStock = max(currentStock - item.quantity, 0);
+          products[productIndex] =
+              products[productIndex].copyWith(stockQuantity: updatedStock);
         }
       }
       await saveProducts(products);


### PR DESCRIPTION
## Summary
- garante que o fechamento de pedidos não gere estoque negativo
- adiciona a dependência de utilitário matemático necessária para o clamp

## Testing
- `flutter analyze` *(falha por dependências ausentes em database_provider.dart)*
- `flutter test` *(falha: diretório de testes inexistente)*

## Checklist
- [x] Escopo: ajuste de estoque ao fechar pedidos
- [ ] Testes: `flutter analyze`, `flutter test` (falharam devido a problemas pré-existentes)
- [x] Breaking changes: não

------
https://chatgpt.com/codex/tasks/task_b_68fe0cf30d108331957aa257179f657e