### PR TITLE
feat: support cancelling orders without affecting inventory

### DIFF
--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -390,8 +390,12 @@ class DatabaseService {
       final tableIndex =
           tables.indexWhere((t) => t.id == orders[index].tableId);
       if (tableIndex != -1) {
-        tables[tableIndex] = tables[tableIndex].copyWith(
+        final table = tables[tableIndex];
+        tables[tableIndex] = TableModel(
+          id: table.id,
+          number: table.number,
           status: TableStatus.free,
+          capacity: table.capacity,
           currentOrderId: null,
         );
         await saveTables(tables);
@@ -403,6 +407,42 @@ class DatabaseService {
         total: orders[index].total,
       );
       await addSale(sale);
+    }
+  }
+
+  Future<void> cancelOrder(String orderId) async {
+    final orders = await getOrders();
+    final index = orders.indexWhere((order) => order.id == orderId);
+    if (index == -1) {
+      return;
+    }
+
+    final canceledItems = orders[index]
+        .items
+        .map((item) => item.status == OrderStatus.canceled
+            ? item
+            : item.copyWith(status: OrderStatus.canceled))
+        .toList();
+
+    orders[index] = orders[index].copyWith(
+      status: OrderStatus.canceled,
+      items: canceledItems,
+      isClosed: true,
+    );
+    await saveOrders(orders);
+
+    final tables = await getTables();
+    final tableIndex = tables.indexWhere((t) => t.id == orders[index].tableId);
+    if (tableIndex != -1) {
+      final table = tables[tableIndex];
+      tables[tableIndex] = TableModel(
+        id: table.id,
+        number: table.number,
+        status: TableStatus.free,
+        capacity: table.capacity,
+        currentOrderId: null,
+      );
+      await saveTables(tables);
     }
   }
 

--- a/lib/presentation/pages/order_details_page.dart
+++ b/lib/presentation/pages/order_details_page.dart
@@ -750,9 +750,10 @@ class _OrderDetailsPageState extends State<OrderDetailsPage> {
         confirmText: 'Sim, Cancelar',
         cancelText: 'Não',
         onConfirm: () async {
-          await _databaseService.closeOrder(_order.id);
+          await _databaseService.cancelOrder(_order.id);
+          Navigator.pop(context);
           if (mounted) {
-            Navigator.pop(context);
+            Navigator.pop(this.context);
           }
         },
       ),

--- a/test/core/services/database_service_test.dart
+++ b/test/core/services/database_service_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:boteco_pro/core/models/data_models.dart';
+import 'package:boteco_pro/core/services/database_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DatabaseService order lifecycle', () {
+    late DatabaseService databaseService;
+    late Order order;
+    late TableModel table;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      databaseService = DatabaseService();
+
+      order = Order(
+        id: 'order-1',
+        tableId: 'table-1',
+        tableNumber: 5,
+        items: [
+          OrderItem(
+            id: 'item-1',
+            productId: 'product-1',
+            productName: 'Test Product',
+            quantity: 2,
+            price: 10,
+          ),
+        ],
+      );
+
+      table = TableModel(
+        id: 'table-1',
+        number: 5,
+        status: TableStatus.occupied,
+        capacity: 4,
+        currentOrderId: order.id,
+      );
+
+      await databaseService.saveOrders([order]);
+      await databaseService.saveTables([table]);
+    });
+
+    test('cancelOrder marks order as canceled and frees the table', () async {
+      await databaseService.cancelOrder(order.id);
+
+      final savedOrders = await databaseService.getOrders();
+      final savedTables = await databaseService.getTables();
+      final sales = await databaseService.getSales();
+
+      expect(savedOrders, hasLength(1));
+      final savedOrder = savedOrders.first;
+      expect(savedOrder.isClosed, isTrue);
+      expect(savedOrder.status, OrderStatus.canceled);
+      expect(
+        savedOrder.items.every((item) => item.status == OrderStatus.canceled),
+        isTrue,
+      );
+
+      expect(savedTables, hasLength(1));
+      final savedTable = savedTables.first;
+      expect(savedTable.status, TableStatus.free);
+      expect(savedTable.currentOrderId, isNull);
+
+      expect(sales, isEmpty);
+    });
+
+    test('closeOrder updates stock, sales and frees the table', () async {
+      final product = Product(
+        id: 'product-1',
+        name: 'Test Product',
+        category: ProductCategory.food,
+        price: 10,
+        stockQuantity: 10,
+        unit: 'unidade',
+      );
+
+      await databaseService.saveProducts([product]);
+
+      await databaseService.closeOrder(order.id);
+
+      final updatedProducts = await databaseService.getProducts();
+      final savedTables = await databaseService.getTables();
+      final sales = await databaseService.getSales();
+      final savedOrder = (await databaseService.getOrders()).first;
+
+      expect(savedOrder.isClosed, isTrue);
+      expect(updatedProducts.first.stockQuantity, 8);
+      expect(savedTables.first.status, TableStatus.free);
+      expect(savedTables.first.currentOrderId, isNull);
+      expect(sales, hasLength(1));
+      expect(sales.first.total, savedOrder.total);
+    });
+  });
+}


### PR DESCRIPTION
## Resumo
- adiciona rotina de cancelamento de pedidos que preserva estoque e libera a mesa
- garante que o fechamento legítimo continue atualizando estoque e vendas
- cria testes unitários cobrindo cancelamento e fechamento de pedidos

## Checklist
- [x] Escopo concluído
- [x] Testes executados
- [ ] Breaking changes

## Validação
- flutter test
- flutter analyze *(falha devido a dependências ausentes em `lib/core/providers/database_provider.dart` já presentes na base)*

------
https://chatgpt.com/codex/tasks/task_b_68fe0ce329d48331a3533678d04268d3