### PR TITLE
docs: clarify auth placeholders roadmap

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -48,6 +48,14 @@ Start here → [WEB_ARCHITECTURE.md](./WEB_ARCHITECTURE.md) (20 min read)
 
 ---
 
+### ⚠️ Estado atual da autenticação (MVP)
+
+- As telas de login e cadastro permanecem como placeholders sem integração real de autenticação nesta fase do MVP.
+- O serviço `lib/core/services/auth_service.dart` ainda está vazio e aguarda implementação futura.
+- Consulte os comentários `TODO(auth)` em `lib/presentation/pages/login_page.dart` e `lib/core/services/auth_service.dart` para direcionamento quando a autenticação entrar no roadmap ativo.
+
+---
+
 ## 🗺️ Reading Paths
 
 ### Path 1: "I just want to launch" (15 minutes)

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -4,6 +4,8 @@
 ///
 /// Este serviço será responsável pela autenticação de usuários no aplicativo.
 /// Atualmente está vazio e pronto para ser implementado quando necessário.
+/// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação")
+/// para orientação completa sobre os próximos passos de desenvolvimento.
 ///
 /// IMPLEMENTAÇÕES FUTURAS PREVISTAS:
 /// 
@@ -55,12 +57,13 @@
 ///
 /// E implemente os métodos seguindo os exemplos no AuthProvider.
 class AuthService {
-  // TODO: Implementar singleton pattern se necessário
+  // TODO(auth): Implementar singleton pattern se necessário (ver docs/DOCUMENTATION_INDEX.md, seção "⚠️ Estado atual da autenticação").
   // static final AuthService _instance = AuthService._internal();
   // factory AuthService() => _instance;
   // AuthService._internal();
 
-  /// TODO: Implementar login com email e senha
+  /// TODO(auth): Implementar login com email e senha.
+  /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para requisitos detalhados.
   /// 
   /// Exemplo com Firebase:
   /// ```dart
@@ -87,7 +90,8 @@ class AuthService {
   /// }
   /// ```
 
-  /// TODO: Implementar cadastro de novo usuário
+  /// TODO(auth): Implementar cadastro de novo usuário.
+  /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para requisitos detalhados.
   /// 
   /// Exemplo com Firebase:
   /// ```dart
@@ -118,7 +122,8 @@ class AuthService {
   /// }
   /// ```
 
-  /// TODO: Implementar login com Google
+  /// TODO(auth): Implementar login com Google.
+  /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para requisitos detalhados.
   /// 
   /// Exemplo com Firebase:
   /// ```dart
@@ -153,7 +158,8 @@ class AuthService {
   /// }
   /// ```
 
-  /// TODO: Implementar logout
+  /// TODO(auth): Implementar logout.
+  /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para requisitos detalhados.
   /// 
   /// Exemplo com Firebase:
   /// ```dart
@@ -163,7 +169,8 @@ class AuthService {
   /// }
   /// ```
 
-  /// TODO: Implementar recuperação de senha
+  /// TODO(auth): Implementar recuperação de senha.
+  /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para requisitos detalhados.
   /// 
   /// Exemplo com Firebase:
   /// ```dart
@@ -176,7 +183,8 @@ class AuthService {
   /// }
   /// ```
 
-  /// TODO: Implementar verificação de usuário autenticado
+  /// TODO(auth): Implementar verificação de usuário autenticado.
+  /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para requisitos detalhados.
   /// 
   /// Exemplo com Firebase:
   /// ```dart
@@ -193,7 +201,8 @@ class AuthService {
   /// }
   /// ```
 
-  /// TODO: Implementar stream de mudanças de autenticação
+  /// TODO(auth): Implementar stream de mudanças de autenticação.
+  /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para requisitos detalhados.
   /// 
   /// Exemplo com Firebase:
   /// ```dart

--- a/lib/presentation/pages/login_page.dart
+++ b/lib/presentation/pages/login_page.dart
@@ -3,7 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../../main.dart';
-// TODO: Descomentar quando implementar autenticação
+// TODO(auth): Descomentar quando implementar autenticação.
+// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para o roadmap de integração.
 // import '../../core/providers/auth_provider.dart';
 // import 'package:provider/provider.dart';
 import 'signup_page.dart';
@@ -16,7 +17,8 @@ import 'signup_page.dart';
 /// - Link para tela de cadastro
 /// - Design responsivo e animado
 ///
-/// TODO: IMPLEMENTAÇÕES FUTURAS
+/// TODO(auth): IMPLEMENTAÇÕES FUTURAS.
+/// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para orientações detalhadas.
 /// 
 /// 1. Integrar com AuthProvider:
 ///    ```dart
@@ -53,7 +55,7 @@ class _LoginPageState extends State<LoginPage> {
     super.dispose();
   }
 
-  // TODO: Implementar login real com AuthProvider
+  // TODO(auth): Implementar login real com AuthProvider (ver docs/DOCUMENTATION_INDEX.md, seção "⚠️ Estado atual da autenticação").
   Future<void> _handleLogin() async {
     if (!_formKey.currentState!.validate()) {
       return;
@@ -63,7 +65,7 @@ class _LoginPageState extends State<LoginPage> {
       _isLoading = true;
     });
 
-    // TODO: Substituir por lógica real de autenticação
+    // TODO(auth): Substituir por lógica real de autenticação (ver docs/DOCUMENTATION_INDEX.md, seção "⚠️ Estado atual da autenticação").
     // Exemplo:
     // try {
     //   final authProvider = context.read<AuthProvider>();
@@ -101,7 +103,7 @@ class _LoginPageState extends State<LoginPage> {
     }
   }
 
-  // TODO: Implementar login com Google
+  // TODO(auth): Implementar login com Google (ver docs/DOCUMENTATION_INDEX.md, seção "⚠️ Estado atual da autenticação").
   Future<void> _handleGoogleLogin() async {
     // Implementação futura
     ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- clarify in DOCUMENTATION_INDEX.md that login, signup, and AuthService remain placeholders in the MVP
- reference the new authentication note from existing TODO(auth) markers in login_page.dart and auth_service.dart

## Testing
- flutter analyze *(fails: unresolved database_provider imports from pre-existing placeholder code)*
- flutter test *(fails: test directory missing in current repository state)*

## Checklist
- [x] Escopo coberto
- [ ] Testes executados com sucesso
- [x] Sem breaking changes


------
https://chatgpt.com/codex/tasks/task_b_68fe0cc58354833196ae75008562a3fe