### PR TITLE
feat: initialize auth provider at app root

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,11 +59,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
+import 'core/providers/auth_provider.dart';
 import 'presentation/pages/home_page.dart';
 import 'presentation/pages/production_page.dart';
 import 'presentation/pages/products_page.dart';
 import 'presentation/pages/recipes_page.dart';
+import 'presentation/pages/login_page.dart';
 import 'presentation/pages/tables_page.dart';
 import 'theme.dart';
 import 'presentation/widgets/bottom_navigation.dart';
@@ -75,7 +78,21 @@ void main() async {
   await initializeDateFormatting('pt_BR', null);
   Intl.defaultLocale = 'pt_BR';
 
-  runApp(const MyApp());
+  runApp(const AppProviders());
+}
+
+class AppProviders extends StatelessWidget {
+  const AppProviders({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<AuthProvider>(create: (_) => AuthProvider()),
+      ],
+      child: const MyApp(),
+    );
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -105,16 +122,31 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    _navigateToHome();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeAndNavigate();
+    });
   }
 
-  Future<void> _navigateToHome() async {
-    await Future.delayed(const Duration(seconds: 2));
-    if (mounted) {
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (context) => const MainNavigationScreen()),
-      );
+  Future<void> _initializeAndNavigate() async {
+    final authProvider = context.read<AuthProvider>();
+
+    if (!authProvider.initialized) {
+      await authProvider.initialize();
     }
+
+    await Future.delayed(const Duration(seconds: 2));
+
+    if (!mounted) {
+      return;
+    }
+
+    final nextPage = authProvider.isSignedIn
+        ? const MainNavigationScreen()
+        : const LoginPage();
+
+    Navigator.of(
+      context,
+    ).pushReplacement(MaterialPageRoute(builder: (context) => nextPage));
   }
 
   @override
@@ -126,41 +158,43 @@ class _SplashScreenState extends State<SplashScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(
-              Icons.sports_bar,
-              size: 80,
-              color: Theme.of(context).colorScheme.onPrimary,
-            )
+                  Icons.sports_bar,
+                  size: 80,
+                  color: Theme.of(context).colorScheme.onPrimary,
+                )
                 .animate(
-                    onPlay: (controller) => controller.repeat(reverse: true))
+                  onPlay: (controller) => controller.repeat(reverse: true),
+                )
                 .scale(
-                    duration: const Duration(seconds: 1),
-                    curve: Curves.easeInOut),
+                  duration: const Duration(seconds: 1),
+                  curve: Curves.easeInOut,
+                ),
             const SizedBox(height: 24),
             Text(
               'Boteco PRO',
               style: Theme.of(context).textTheme.headlineSmall!.copyWith(
-                    fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.onPrimary,
-                  ),
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.onPrimary,
+              ),
             ).animate().fadeIn(
-                duration: const Duration(milliseconds: 800),
-                curve: Curves.easeIn),
+              duration: const Duration(milliseconds: 800),
+              curve: Curves.easeIn,
+            ),
             const SizedBox(height: 8),
             Text(
               'Gestão completa para seu bar',
               style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onPrimary
-                        .withOpacity(0.8),
-                  ),
+                color: Theme.of(context).colorScheme.onPrimary.withOpacity(0.8),
+              ),
             ).animate().fadeIn(
-                delay: const Duration(milliseconds: 400),
-                duration: const Duration(milliseconds: 800)),
+              delay: const Duration(milliseconds: 400),
+              duration: const Duration(milliseconds: 800),
+            ),
             const SizedBox(height: 48),
             CircularProgressIndicator(
               valueColor: AlwaysStoppedAnimation<Color>(
-                  Theme.of(context).colorScheme.onPrimary),
+                Theme.of(context).colorScheme.onPrimary,
+              ),
             ),
           ],
         ),
@@ -202,7 +236,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   @override
   Widget build(BuildContext context) {
     final isWebLarge = MediaQuery.of(context).size.width > 800;
-    
+
     if (isWebLarge) {
       // Layout desktop/web avec sidebar
       return Scaffold(
@@ -211,7 +245,8 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
             // Navigation latérale
             NavigationRail(
               selectedIndex: _currentTab.index,
-              onDestinationSelected: (index) => _selectTab(NavigationTab.values[index]),
+              onDestinationSelected: (index) =>
+                  _selectTab(NavigationTab.values[index]),
               backgroundColor: Theme.of(context).colorScheme.surface,
               leading: Container(
                 padding: const EdgeInsets.all(16),
@@ -260,7 +295,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
         ),
       );
     }
-    
+
     // Layout mobile avec bottom navigation
     return Scaffold(
       body: IndexedStack(

--- a/lib/presentation/pages/login_page.dart
+++ b/lib/presentation/pages/login_page.dart
@@ -2,6 +2,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:provider/provider.dart';
+import '../../core/providers/auth_provider.dart';
 import '../../main.dart';
 // TODO(auth): Descomentar quando implementar autenticação.
 // Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para o roadmap de integração.
@@ -19,7 +21,7 @@ import 'signup_page.dart';
 ///
 /// TODO(auth): IMPLEMENTAÇÕES FUTURAS.
 /// Consulte docs/DOCUMENTATION_INDEX.md (Seção "⚠️ Estado atual da autenticação") para orientações detalhadas.
-/// 
+///
 /// 1. Integrar com AuthProvider:
 ///    ```dart
 ///    final authProvider = context.read<AuthProvider>();
@@ -73,7 +75,7 @@ class _LoginPageState extends State<LoginPage> {
     //     _emailController.text.trim(),
     //     _passwordController.text,
     //   );
-    //   
+    //
     //   if (mounted) {
     //     Navigator.of(context).pushReplacement(
     //       MaterialPageRoute(builder: (_) => const MainNavigationScreen()),
@@ -93,13 +95,32 @@ class _LoginPageState extends State<LoginPage> {
     //   }
     // }
 
-    // TEMPORÁRIO: Bypass de autenticação para desenvolvimento
-    await Future.delayed(const Duration(seconds: 1));
-    
-    if (mounted) {
+    try {
+      final authProvider = context.read<AuthProvider>();
+      await authProvider.signInWithEmail(
+        _emailController.text.trim(),
+        _passwordController.text,
+      );
+
+      if (!mounted) {
+        return;
+      }
+
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(builder: (_) => const MainNavigationScreen()),
       );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Erro ao fazer login: $e')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 
@@ -131,110 +152,119 @@ class _LoginPageState extends State<LoginPage> {
                   children: [
                     // Logo
                     Icon(
-                      Icons.sports_bar,
-                      size: 80,
-                      color: Theme.of(context).colorScheme.primary,
-                    )
+                          Icons.sports_bar,
+                          size: 80,
+                          color: Theme.of(context).colorScheme.primary,
+                        )
                         .animate()
                         .fadeIn(duration: const Duration(milliseconds: 600))
                         .scale(delay: const Duration(milliseconds: 200)),
-                    
+
                     const SizedBox(height: 24),
-                    
+
                     // Título
                     Text(
                       'Boteco PRO',
                       textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.headlineMedium!.copyWith(
+                      style: Theme.of(context).textTheme.headlineMedium!
+                          .copyWith(
                             fontWeight: FontWeight.bold,
                             color: Theme.of(context).colorScheme.primary,
                           ),
-                    )
-                        .animate()
-                        .fadeIn(delay: const Duration(milliseconds: 300)),
-                    
+                    ).animate().fadeIn(
+                      delay: const Duration(milliseconds: 300),
+                    ),
+
                     const SizedBox(height: 8),
-                    
+
                     Text(
                       'Gestão completa para seu bar',
                       textAlign: TextAlign.center,
                       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                            color: Theme.of(context).colorScheme.onSurface.withAlpha(179),
-                          ),
-                    )
-                        .animate()
-                        .fadeIn(delay: const Duration(milliseconds: 400)),
-                    
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withAlpha(179),
+                      ),
+                    ).animate().fadeIn(
+                      delay: const Duration(milliseconds: 400),
+                    ),
+
                     const SizedBox(height: 48),
-                    
+
                     // Campo Email
                     TextFormField(
-                      controller: _emailController,
-                      keyboardType: TextInputType.emailAddress,
-                      decoration: InputDecoration(
-                        labelText: 'Email',
-                        hintText: 'seu@email.com',
-                        prefixIcon: const Icon(Icons.email_outlined),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor, insira seu email';
-                        }
-                        if (!value.contains('@')) {
-                          return 'Email inválido';
-                        }
-                        return null;
-                      },
-                    )
+                          controller: _emailController,
+                          keyboardType: TextInputType.emailAddress,
+                          decoration: InputDecoration(
+                            labelText: 'Email',
+                            hintText: 'seu@email.com',
+                            prefixIcon: const Icon(Icons.email_outlined),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Por favor, insira seu email';
+                            }
+                            if (!value.contains('@')) {
+                              return 'Email inválido';
+                            }
+                            return null;
+                          },
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 500))
-                        .moveX(begin: -30, delay: const Duration(milliseconds: 500)),
-                    
+                        .moveX(
+                          begin: -30,
+                          delay: const Duration(milliseconds: 500),
+                        ),
+
                     const SizedBox(height: 16),
-                    
+
                     // Campo Senha
                     TextFormField(
-                      controller: _passwordController,
-                      obscureText: _obscurePassword,
-                      decoration: InputDecoration(
-                        labelText: 'Senha',
-                        hintText: '••••••••',
-                        prefixIcon: const Icon(Icons.lock_outlined),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _obscurePassword
-                                ? Icons.visibility_outlined
-                                : Icons.visibility_off_outlined,
+                          controller: _passwordController,
+                          obscureText: _obscurePassword,
+                          decoration: InputDecoration(
+                            labelText: 'Senha',
+                            hintText: '••••••••',
+                            prefixIcon: const Icon(Icons.lock_outlined),
+                            suffixIcon: IconButton(
+                              icon: Icon(
+                                _obscurePassword
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  _obscurePassword = !_obscurePassword;
+                                });
+                              },
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                           ),
-                          onPressed: () {
-                            setState(() {
-                              _obscurePassword = !_obscurePassword;
-                            });
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Por favor, insira sua senha';
+                            }
+                            if (value.length < 6) {
+                              return 'Senha deve ter pelo menos 6 caracteres';
+                            }
+                            return null;
                           },
-                        ),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor, insira sua senha';
-                        }
-                        if (value.length < 6) {
-                          return 'Senha deve ter pelo menos 6 caracteres';
-                        }
-                        return null;
-                      },
-                    )
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 600))
-                        .moveX(begin: -30, delay: const Duration(milliseconds: 600)),
-                    
+                        .moveX(
+                          begin: -30,
+                          delay: const Duration(milliseconds: 600),
+                        ),
+
                     const SizedBox(height: 8),
-                    
+
                     // Link Esqueci a Senha
                     Align(
                       alignment: Alignment.centerRight,
@@ -243,7 +273,9 @@ class _LoginPageState extends State<LoginPage> {
                           // TODO: Implementar recuperação de senha
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(
-                              content: Text('Recuperação de senha será implementada em breve'),
+                              content: Text(
+                                'Recuperação de senha será implementada em breve',
+                              ),
                             ),
                           );
                         },
@@ -255,43 +287,49 @@ class _LoginPageState extends State<LoginPage> {
                         ),
                       ),
                     ),
-                    
+
                     const SizedBox(height: 24),
-                    
+
                     // Botão Entrar
                     ElevatedButton(
-                      onPressed: _isLoading ? null : _handleLogin,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Theme.of(context).colorScheme.primary,
-                        foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      child: _isLoading
-                          ? const SizedBox(
-                              height: 20,
-                              width: 20,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                              ),
-                            )
-                          : const Text(
-                              'Entrar',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
+                          onPressed: _isLoading ? null : _handleLogin,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Theme.of(
+                              context,
+                            ).colorScheme.primary,
+                            foregroundColor: Theme.of(
+                              context,
+                            ).colorScheme.onPrimary,
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
                             ),
-                    )
+                          ),
+                          child: _isLoading
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      Colors.white,
+                                    ),
+                                  ),
+                                )
+                              : const Text(
+                                  'Entrar',
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 700))
                         .scale(delay: const Duration(milliseconds: 700)),
-                    
+
                     const SizedBox(height: 24),
-                    
+
                     // Divider
                     Row(
                       children: [
@@ -301,16 +339,18 @@ class _LoginPageState extends State<LoginPage> {
                           child: Text(
                             'OU',
                             style: TextStyle(
-                              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurface.withOpacity(0.6),
                             ),
                           ),
                         ),
                         const Expanded(child: Divider()),
                       ],
                     ),
-                    
+
                     const SizedBox(height: 24),
-                    
+
                     // Botão Google
                     OutlinedButton.icon(
                       onPressed: _handleGoogleLogin,
@@ -322,12 +362,12 @@ class _LoginPageState extends State<LoginPage> {
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                    )
-                        .animate()
-                        .fadeIn(delay: const Duration(milliseconds: 800)),
-                    
+                    ).animate().fadeIn(
+                      delay: const Duration(milliseconds: 800),
+                    ),
+
                     const SizedBox(height: 32),
-                    
+
                     // Link para Cadastro
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -335,13 +375,17 @@ class _LoginPageState extends State<LoginPage> {
                         Text(
                           'Não tem uma conta? ',
                           style: TextStyle(
-                            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurface.withOpacity(0.7),
                           ),
                         ),
                         TextButton(
                           onPressed: () {
                             Navigator.of(context).push(
-                              MaterialPageRoute(builder: (_) => const SignupPage()),
+                              MaterialPageRoute(
+                                builder: (_) => const SignupPage(),
+                              ),
                             );
                           },
                           child: Text(

--- a/lib/presentation/pages/signup_page.dart
+++ b/lib/presentation/pages/signup_page.dart
@@ -2,6 +2,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:provider/provider.dart';
+import '../../core/providers/auth_provider.dart';
+import '../../main.dart';
 // TODO: Descomentar quando implementar autenticação
 // import '../../core/providers/auth_provider.dart';
 // import 'package:provider/provider.dart';
@@ -15,7 +18,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 /// - Design responsivo e animado
 ///
 /// TODO: IMPLEMENTAÇÕES FUTURAS
-/// 
+///
 /// 1. Integrar com AuthProvider:
 ///    ```dart
 ///    final authProvider = context.read<AuthProvider>();
@@ -86,7 +89,7 @@ class _SignupPageState extends State<SignupPage> {
     //     email: _emailController.text.trim(),
     //     password: _passwordController.text,
     //   );
-    //   
+    //
     //   if (mounted) {
     //     ScaffoldMessenger.of(context).showSnackBar(
     //       const SnackBar(
@@ -110,20 +113,33 @@ class _SignupPageState extends State<SignupPage> {
     //   }
     // }
 
-    // TEMPORÁRIO: Simulação de cadastro para desenvolvimento
-    await Future.delayed(const Duration(seconds: 1));
-    
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Cadastro será implementado em breve!'),
-          backgroundColor: Colors.blue,
-        ),
+    try {
+      final authProvider = context.read<AuthProvider>();
+      await authProvider.signUpWithEmail(
+        _emailController.text.trim(),
+        _passwordController.text,
       );
-      setState(() {
-        _isLoading = false;
-      });
-      Navigator.of(context).pop();
+
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const MainNavigationScreen()),
+        (route) => false,
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Erro ao cadastrar: $e')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 
@@ -156,179 +172,195 @@ class _SignupPageState extends State<SignupPage> {
                   children: [
                     // Logo
                     Icon(
-                      Icons.sports_bar,
-                      size: 80,
-                      color: Theme.of(context).colorScheme.primary,
-                    )
+                          Icons.sports_bar,
+                          size: 80,
+                          color: Theme.of(context).colorScheme.primary,
+                        )
                         .animate()
                         .fadeIn(duration: const Duration(milliseconds: 600))
                         .scale(delay: const Duration(milliseconds: 200)),
-                    
+
                     const SizedBox(height: 24),
-                    
+
                     // Título
                     Text(
                       'Criar Conta',
                       textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.headlineMedium!.copyWith(
+                      style: Theme.of(context).textTheme.headlineMedium!
+                          .copyWith(
                             fontWeight: FontWeight.bold,
                             color: Theme.of(context).colorScheme.primary,
                           ),
-                    )
-                        .animate()
-                        .fadeIn(delay: const Duration(milliseconds: 300)),
-                    
+                    ).animate().fadeIn(
+                      delay: const Duration(milliseconds: 300),
+                    ),
+
                     const SizedBox(height: 8),
-                    
+
                     Text(
                       'Comece a gerenciar seu bar agora',
                       textAlign: TextAlign.center,
                       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                            color: Theme.of(context).colorScheme.onSurface.withAlpha(179),
-                          ),
-                    )
-                        .animate()
-                        .fadeIn(delay: const Duration(milliseconds: 400)),
-                    
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withAlpha(179),
+                      ),
+                    ).animate().fadeIn(
+                      delay: const Duration(milliseconds: 400),
+                    ),
+
                     const SizedBox(height: 32),
-                    
+
                     // Campo Nome
                     TextFormField(
-                      controller: _nameController,
-                      keyboardType: TextInputType.name,
-                      textCapitalization: TextCapitalization.words,
-                      decoration: InputDecoration(
-                        labelText: 'Nome completo',
-                        hintText: 'João Silva',
-                        prefixIcon: const Icon(Icons.person_outlined),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor, insira seu nome';
-                        }
-                        if (value.length < 3) {
-                          return 'Nome deve ter pelo menos 3 caracteres';
-                        }
-                        return null;
-                      },
-                    )
+                          controller: _nameController,
+                          keyboardType: TextInputType.name,
+                          textCapitalization: TextCapitalization.words,
+                          decoration: InputDecoration(
+                            labelText: 'Nome completo',
+                            hintText: 'João Silva',
+                            prefixIcon: const Icon(Icons.person_outlined),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Por favor, insira seu nome';
+                            }
+                            if (value.length < 3) {
+                              return 'Nome deve ter pelo menos 3 caracteres';
+                            }
+                            return null;
+                          },
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 500))
-                        .moveX(begin: -30, delay: const Duration(milliseconds: 500)),
-                    
+                        .moveX(
+                          begin: -30,
+                          delay: const Duration(milliseconds: 500),
+                        ),
+
                     const SizedBox(height: 16),
-                    
+
                     // Campo Email
                     TextFormField(
-                      controller: _emailController,
-                      keyboardType: TextInputType.emailAddress,
-                      decoration: InputDecoration(
-                        labelText: 'Email',
-                        hintText: 'seu@email.com',
-                        prefixIcon: const Icon(Icons.email_outlined),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor, insira seu email';
-                        }
-                        if (!value.contains('@') || !value.contains('.')) {
-                          return 'Email inválido';
-                        }
-                        return null;
-                      },
-                    )
+                          controller: _emailController,
+                          keyboardType: TextInputType.emailAddress,
+                          decoration: InputDecoration(
+                            labelText: 'Email',
+                            hintText: 'seu@email.com',
+                            prefixIcon: const Icon(Icons.email_outlined),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Por favor, insira seu email';
+                            }
+                            if (!value.contains('@') || !value.contains('.')) {
+                              return 'Email inválido';
+                            }
+                            return null;
+                          },
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 600))
-                        .moveX(begin: -30, delay: const Duration(milliseconds: 600)),
-                    
+                        .moveX(
+                          begin: -30,
+                          delay: const Duration(milliseconds: 600),
+                        ),
+
                     const SizedBox(height: 16),
-                    
+
                     // Campo Senha
                     TextFormField(
-                      controller: _passwordController,
-                      obscureText: _obscurePassword,
-                      decoration: InputDecoration(
-                        labelText: 'Senha',
-                        hintText: '••••••••',
-                        prefixIcon: const Icon(Icons.lock_outlined),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _obscurePassword
-                                ? Icons.visibility_outlined
-                                : Icons.visibility_off_outlined,
+                          controller: _passwordController,
+                          obscureText: _obscurePassword,
+                          decoration: InputDecoration(
+                            labelText: 'Senha',
+                            hintText: '••••••••',
+                            prefixIcon: const Icon(Icons.lock_outlined),
+                            suffixIcon: IconButton(
+                              icon: Icon(
+                                _obscurePassword
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  _obscurePassword = !_obscurePassword;
+                                });
+                              },
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                           ),
-                          onPressed: () {
-                            setState(() {
-                              _obscurePassword = !_obscurePassword;
-                            });
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Por favor, insira sua senha';
+                            }
+                            if (value.length < 6) {
+                              return 'Senha deve ter pelo menos 6 caracteres';
+                            }
+                            return null;
                           },
-                        ),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor, insira sua senha';
-                        }
-                        if (value.length < 6) {
-                          return 'Senha deve ter pelo menos 6 caracteres';
-                        }
-                        return null;
-                      },
-                    )
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 700))
-                        .moveX(begin: -30, delay: const Duration(milliseconds: 700)),
-                    
+                        .moveX(
+                          begin: -30,
+                          delay: const Duration(milliseconds: 700),
+                        ),
+
                     const SizedBox(height: 16),
-                    
+
                     // Campo Confirmar Senha
                     TextFormField(
-                      controller: _confirmPasswordController,
-                      obscureText: _obscureConfirmPassword,
-                      decoration: InputDecoration(
-                        labelText: 'Confirmar senha',
-                        hintText: '••••••••',
-                        prefixIcon: const Icon(Icons.lock_outlined),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _obscureConfirmPassword
-                                ? Icons.visibility_outlined
-                                : Icons.visibility_off_outlined,
+                          controller: _confirmPasswordController,
+                          obscureText: _obscureConfirmPassword,
+                          decoration: InputDecoration(
+                            labelText: 'Confirmar senha',
+                            hintText: '••••••••',
+                            prefixIcon: const Icon(Icons.lock_outlined),
+                            suffixIcon: IconButton(
+                              icon: Icon(
+                                _obscureConfirmPassword
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  _obscureConfirmPassword =
+                                      !_obscureConfirmPassword;
+                                });
+                              },
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                           ),
-                          onPressed: () {
-                            setState(() {
-                              _obscureConfirmPassword = !_obscureConfirmPassword;
-                            });
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Por favor, confirme sua senha';
+                            }
+                            if (value != _passwordController.text) {
+                              return 'As senhas não coincidem';
+                            }
+                            return null;
                           },
-                        ),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'Por favor, confirme sua senha';
-                        }
-                        if (value != _passwordController.text) {
-                          return 'As senhas não coincidem';
-                        }
-                        return null;
-                      },
-                    )
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 800))
-                        .moveX(begin: -30, delay: const Duration(milliseconds: 800)),
-                    
+                        .moveX(
+                          begin: -30,
+                          delay: const Duration(milliseconds: 800),
+                        ),
+
                     const SizedBox(height: 16),
-                    
+
                     // Checkbox Termos
                     Row(
                       children: [
@@ -351,7 +383,9 @@ class _SignupPageState extends State<SignupPage> {
                             child: Text(
                               'Aceito os termos de uso e política de privacidade',
                               style: TextStyle(
-                                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurface.withOpacity(0.8),
                                 fontSize: 13,
                               ),
                             ),
@@ -359,43 +393,49 @@ class _SignupPageState extends State<SignupPage> {
                         ),
                       ],
                     ),
-                    
+
                     const SizedBox(height: 24),
-                    
+
                     // Botão Cadastrar
                     ElevatedButton(
-                      onPressed: _isLoading ? null : _handleSignup,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Theme.of(context).colorScheme.primary,
-                        foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      child: _isLoading
-                          ? const SizedBox(
-                              height: 20,
-                              width: 20,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                              ),
-                            )
-                          : const Text(
-                              'Cadastrar',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
+                          onPressed: _isLoading ? null : _handleSignup,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Theme.of(
+                              context,
+                            ).colorScheme.primary,
+                            foregroundColor: Theme.of(
+                              context,
+                            ).colorScheme.onPrimary,
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
                             ),
-                    )
+                          ),
+                          child: _isLoading
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      Colors.white,
+                                    ),
+                                  ),
+                                )
+                              : const Text(
+                                  'Cadastrar',
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                        )
                         .animate()
                         .fadeIn(delay: const Duration(milliseconds: 900))
                         .scale(delay: const Duration(milliseconds: 900)),
-                    
+
                     const SizedBox(height: 24),
-                    
+
                     // Link para Login
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -403,7 +443,9 @@ class _SignupPageState extends State<SignupPage> {
                         Text(
                           'Já tem uma conta? ',
                           style: TextStyle(
-                            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurface.withOpacity(0.7),
                           ),
                         ),
                         TextButton(


### PR DESCRIPTION
## Resumo
- envolve o aplicativo em um MultiProvider para expor o AuthProvider desde a raiz.
- ajusta a SplashScreen para aguardar AuthProvider.initialize() antes de enviar o usuário para as rotas principais ou de login.
- conecta as telas de login e cadastro ao AuthProvider utilizando context.read para autenticação real.

## Testes
- flutter analyze *(falhou: dependências opcionais ausentes em lib/core/providers/database_provider.dart)*
- flutter test *(falhou: expectativas existentes em DatabaseService cancelOrder/closeOrder)*

------
https://chatgpt.com/codex/tasks/task_b_68fe1ce8c834833190270b070e50eb35